### PR TITLE
Unmask password/key entry

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,7 @@ type MailConfig struct {
 	Protocol string       `yaml:"protocol"`
 	Port     int          `yaml:"port"`
 	Username string       `yaml:"username"`
-	Password utils.Secret `yaml:"password"`
+	Password string       `yaml:"password"`
 }
 
 // GlobalConfig configures values that are used to config Faythe HTTP server
@@ -54,8 +54,8 @@ type GlobalConfig struct {
 // BasicAuthentication - HTTP Basic authentication.
 type BasicAuthentication struct {
 	// Usename, Password to implement HTTP basic authentication
-	Username string       `yaml:"username"`
-	Password utils.Secret `yaml:"password"`
+	Username string  `yaml:"username"`
+	Password string  `yaml:"password"`
 }
 
 // EtcdConfig stores Etcd related configurations.
@@ -98,7 +98,7 @@ type EtcdConfig struct {
 	Username string `yaml:"username,omitempty"`
 
 	// Password is a password for authentication.
-	Password utils.Secret `yaml:"password,omitempty"`
+	Password string `yaml:"password,omitempty"`
 
 	// RejectOldCluster when set will refuse to create a client against an outdated cluster.
 	RejectOldCluster bool `yaml:"reject_old_cluster,omitempty"`

--- a/pkg/model/atengine.go
+++ b/pkg/model/atengine.go
@@ -26,7 +26,7 @@ type ATEngine struct {
 	Address  URL               `json:"address"`
 	Metadata map[string]string `json:"metadata"`
 	Username string            `json:"username,omitempty"`
-	Password utils.Secret      `json:"password,omitempty"`
+	Password string            `json:"password,omitempty"`
 	APIKey   string            `json:"apikey,omitempty"`
 }
 

--- a/pkg/model/cloud.go
+++ b/pkg/model/cloud.go
@@ -85,7 +85,7 @@ type OpenStackAuth struct {
 	Username string `json:"username"`
 	UserID   string `json:"userid"`
 
-	Password utils.Secret `json:"password"`
+	Password string `json:"password"`
 
 	// At most one of DomainID and DomainName must be provided if using Username
 	// with Identity V3. Otherwise, either are optional.

--- a/pkg/model/monitor.go
+++ b/pkg/model/monitor.go
@@ -22,5 +22,5 @@ type Monitor struct {
 	Address  URL               `json:"address"`
 	Metadata map[string]string `json:"metadata"`
 	Username string            `json:"username,omitempty"`
-	Password utils.Secret      `json:"password,omitempty"`
+	Password string            `json:"password,omitempty"`
 }

--- a/pkg/model/monitor.go
+++ b/pkg/model/monitor.go
@@ -14,11 +14,13 @@
 
 package model
 
+import "github.com/vCloud-DFTBA/faythe/pkg/utils"
+
 // Monitor represents a monitor backend
 type Monitor struct {
 	Backend  string            `json:"backend"`
 	Address  URL               `json:"address"`
 	Metadata map[string]string `json:"metadata"`
 	Username string            `json:"username,omitempty"`
-	Password string            `json:"password,omitempty"`
+	Password utils.Secret      `json:"password,omitempty"`
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -117,9 +117,6 @@ func Path(keys ...string) string {
 	return strings.Join(append([]string{}, keys...), "/")
 }
 
-// Secret special type for storing secrets.
-type Secret string
-
 // Find tells whether string contains x.
 // op - boolean operator, expected `AND` `OR` string value.
 // x - could be string or slice of string.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -120,27 +120,6 @@ func Path(keys ...string) string {
 // Secret special type for storing secrets.
 type Secret string
 
-// MarshalYAML implements the yaml.Marshaler interface for Secrets.
-func (s Secret) MarshalYAML() (interface{}, error) {
-	if s != "" {
-		return "<secret>", nil
-	}
-	return nil, nil
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface for Secrets.
-func (s *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	type plain Secret
-	return unmarshal((*plain)(s))
-}
-
-func (s Secret) MarshalJSON() ([]byte, error) {
-	if s != "" {
-		return []byte(`"<secret>"`), nil
-	}
-	return nil, nil
-}
-
 // Find tells whether string contains x.
 // op - boolean operator, expected `AND` `OR` string value.
 // x - could be string or slice of string.


### PR DESCRIPTION
Since using masking method, when we store those information in
etcd, it will become  in plain text. Retrieving those
for the next time will cause the wrong password/key.

Close #50