### PR TITLE
Notify about failed mistral executions

### DIFF
--- a/pkg/autohealer/healer.go
+++ b/pkg/autohealer/healer.go
@@ -192,7 +192,6 @@ func (h *Healer) run(ctx context.Context, e *common.Etcd, wg *sync.WaitGroup, nc
 					continue
 				}
 
-
 				for instance := range rIs {
 					if _, ok := chans[instance]; !ok {
 						ci := make(chan struct{})
@@ -265,23 +264,6 @@ func (h *Healer) do(compute string) {
 						at.InfoLog()...))
 					level.Error(h.logger).Log(msg...)
 					exporter.ReportFailureHealerActionCounter(cluster.GetID(), "http")
-					m := &model.ActionMail{
-						Receivers: h.Receivers,
-						Subject:   fmt.Sprintf("[autohealing] Node %s down, failed to trigger http request", compute),
-						Body: fmt.Sprintf("Node %s is down for more than %s.\nBut failed to trigger autohealing, due to %s",
-							compute, h.Duration, err.Error()),
-					}
-					_ = m.Validate()
-					if err := alert.SendMail(m); err != nil {
-						msg = common.CnvSliceStrToSliceInf(append([]string{
-							"msg", "Exec action failed",
-							"err", err.Error()},
-							at.InfoLog()...))
-						level.Error(h.logger).Log(msg...)
-						exporter.ReportFailureHealerActionCounter(cluster.GetID(), "mail")
-						return
-					}
-					exporter.ReportFailureHealerActionCounter(cluster.GetID(), "mail")
 					return
 				}
 				exporter.ReportSuccessHealerActionCounter(cluster.GetID(), "http")
@@ -315,6 +297,7 @@ func (h *Healer) do(compute string) {
 			wg.Add(1)
 			go func(compute string) {
 				defer wg.Done()
+				var msg []interface{}
 				mc := config.Get().MailConfig
 				at.Input = map[string]interface{}{
 					"compute":       compute,
@@ -335,6 +318,21 @@ func (h *Healer) do(compute string) {
 				if err := tracker.start(); err != nil {
 					level.Error(h.logger).Log("msg", "error doing Mistral action", "err", err)
 					exporter.ReportFailureHealerActionCounter(cluster.GetID(), "mistral")
+					m := &model.ActionMail{
+						Receivers: h.Receivers,
+						Subject:   fmt.Sprintf("[autohealing] Node %s down, mistral workflow execution failed", compute),
+						Body: fmt.Sprintf("Node %s is down for more than %s.\nMistral workflow executions has exceeded maxinum number of retry.",
+							compute, h.Duration),
+					}
+					_ = m.Validate()
+					if err := alert.SendMail(m); err != nil {
+						msg = common.CnvSliceStrToSliceInf(append([]string{
+							"msg", "Error while sending email notifying mistral action failed",
+							"err", err.Error()},
+							at.InfoLog()...))
+						level.Error(h.logger).Log(msg...)
+						return
+					}
 					return
 				}
 				exporter.ReportSuccessHealerActionCounter(cluster.GetID(), "mistral")


### PR DESCRIPTION
If number of mistral workflow executions exceed maximum retries number and still failed, send an email to all receivers.