### PR TITLE
Search for Cloud info in Etcd if there is no instance in store

### DIFF
--- a/cmd/faythe/main.go
+++ b/cmd/faythe/main.go
@@ -165,8 +165,8 @@ func main() {
 	go fah.Run()
 
 	// Init Cloud store
-	openstack.InitStore()
-	if err := openstack.Load(etcdcli); err != nil {
+	openstack.InitStore(etcdcli)
+	if err := openstack.Load(); err != nil {
 		level.Error(logger).Log("msg", "error while loading cloud information", "err", err)
 	}
 

--- a/pkg/cloud/store/openstack/store.go
+++ b/pkg/cloud/store/openstack/store.go
@@ -41,7 +41,6 @@ func (s *Store) Get(key string) (model.OpenStack, bool) {
 	value, ok := s.clouds[key]
 	if !ok {
 		// Try to get Cloud provider info from Etcd
-		// Check the issue: https://github.com/vCloud-DFTBA/faythe/issues/23
 		r, err := s.etcdcli.DoGet(common.Path(model.DefaultCloudPrefix, key))
 		if err != nil || len(r.Kvs) != 1 {
 			return value, ok

--- a/pkg/cloud/store/openstack/store.go
+++ b/pkg/cloud/store/openstack/store.go
@@ -28,8 +28,9 @@ import (
 
 // Store supports get and set cloud information
 type Store struct {
-	mtx    sync.RWMutex
-	clouds map[string]model.OpenStack
+	mtx     sync.RWMutex
+	etcdcli *common.Etcd
+	clouds  map[string]model.OpenStack
 }
 
 // Get returns cloud information
@@ -38,6 +39,21 @@ func (s *Store) Get(key string) (model.OpenStack, bool) {
 	defer s.mtx.RUnlock()
 
 	value, ok := s.clouds[key]
+	if !ok {
+		// Try to get Cloud provider info from Etcd
+		// Check the issue: https://github.com/vCloud-DFTBA/faythe/issues/23
+		r, err := s.etcdcli.DoGet(common.Path(model.DefaultCloudPrefix, key))
+		if err != nil || len(r.Kvs) != 1 {
+			return value, ok
+		}
+		cloud := model.OpenStack{}
+		if err := json.Unmarshal(r.Kvs[0].Value, &cloud); err != nil {
+			return value, ok
+		}
+		s.Set(key, cloud)
+		value = cloud
+		ok = true
+	}
 	return value, ok
 }
 
@@ -60,15 +76,16 @@ func (s *Store) Delete(key string) {
 var s *Store
 
 // InitStore creates a new store
-func InitStore() {
+func InitStore(e *common.Etcd) {
 	s = &Store{
-		clouds: map[string]model.OpenStack{},
+		etcdcli: e,
+		clouds:  map[string]model.OpenStack{},
 	}
 }
 
 // Load retrieves cloud information from etcd
-func Load(e *common.Etcd) error {
-	r, err := e.DoGet(model.DefaultCloudPrefix, etcdv3.WithPrefix())
+func Load() error {
+	r, err := s.etcdcli.DoGet(model.DefaultCloudPrefix, etcdv3.WithPrefix())
 	if err != nil {
 		return fmt.Errorf("error getting list of clouds from etcd")
 	}


### PR DESCRIPTION
When registering Cloud, only node receiving request has the
Cloud info in its local store. Try to get Cloud info from Etcd
if the Cloud instance isn't existing.

Closes: #23