### PR TITLE
Graceful shutdown Faythe when keep-alive channel is closed

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -167,7 +167,7 @@ var (
 		DialTimeout:          etcdDefaultDialTimeout,
 		DialKeepAliveTime:    etcdDefaultKeepAliveTime,
 		DialKeepAliveTimeout: etcdDefaultKeepAliveTimeOut,
-		DialOptions:          []grpc.DialOption{grpc.WithBlock()},
+		DialOptions:          []grpc.DialOption{grpc.WithBlock()}, // block until the underlying connection is up
 	}
 
 	// DefaultJWTConfig is the default JWT configuration.

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -154,23 +154,10 @@ func (c *Cluster) join() error {
 
 	// This will keep the key alive 'forever' or until we revoke it
 	// or the connect is canceled.
-	keepAliveRespCh, err := c.etcdcli.DoKeepAlive(c.lease)
+	err = c.etcdcli.DoKeepAlive(c.lease)
 	if err != nil {
 		return err
 	}
-	// discard the keepalive response, make etcd library not to complain
-	// If the keepalive channel is not served, etcd library prints a lot of
-	// log like this, every 3 seconds:
-	// {"level":"warn","ts":1542791960.4143248,"caller":"clientv3/lease.go:524","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
-	go func() {
-		for {
-			r := <-keepAliveRespCh
-			// avoid dead loop when channel was closed
-			if r == nil {
-				return
-			}
-		}
-	}()
 
 	c.setState(ClusterAlive)
 	exporter.RegisterMemberInfo(c.id, c.local)

--- a/pkg/common/etcd.go
+++ b/pkg/common/etcd.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"context"
+	"github.com/pkg/errors"
 	"strconv"
 	"strings"
 	"time"
@@ -278,7 +279,7 @@ func (e *Etcd) DoKeepAliveOnce(id etcdv3.LeaseID) (*etcdv3.LeaseKeepAliveRespons
 // The returned "LeaseKeepAliveResponse" channel closes if underlying keep
 // alive stream is interrupted in some way the client cannot handle itself;
 // given context "ctx" is canceled or timed out.
-func (e *Etcd) DoKeepAlive(id etcdv3.LeaseID) (<-chan *etcdv3.LeaseKeepAliveResponse, error) {
+func (e *Etcd) DoKeepAlive(id etcdv3.LeaseID) error {
 	var (
 		result <-chan *etcdv3.LeaseKeepAliveResponse
 		err    error
@@ -288,7 +289,23 @@ func (e *Etcd) DoKeepAlive(id etcdv3.LeaseID) (<-chan *etcdv3.LeaseKeepAliveResp
 		eerr := NewEtcdErr("", "keep-alive", err)
 		e.ErrCh <- eerr
 	}
-	return result, err
+
+	// discard the keepalive response, make etcd library not to complain
+	// If the keepalive channel is not served, etcd library prints a lot of
+	// log like this, every 3 seconds:
+	// {"level":"warn","ts":1542791960.4143248,"caller":"clientv3/lease.go:524","msg":"lease keepalive response queue is full; dropping response send","queue-size":16,"queue-capacity":16}
+	go func() {
+		for {
+			r := <-result
+			// avoid dead loop when channel was closed
+			if r == nil {
+				eerr := NewEtcdErr("", "keeo-alive", errors.New("KeepAlive channel is closed"))
+				e.ErrCh <- eerr
+				return
+			}
+		}
+	}()
+	return err
 }
 
 // DoRevoke revokes the given lease.

--- a/pkg/common/etcd.go
+++ b/pkg/common/etcd.go
@@ -16,13 +16,13 @@ package common
 
 import (
 	"context"
-	"github.com/pkg/errors"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	etcdv3 "go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/clientv3/namespace"

--- a/pkg/common/etcd.go
+++ b/pkg/common/etcd.go
@@ -299,7 +299,7 @@ func (e *Etcd) DoKeepAlive(id etcdv3.LeaseID) error {
 			r := <-result
 			// avoid dead loop when channel was closed
 			if r == nil {
-				eerr := NewEtcdErr("", "keeo-alive", errors.New("KeepAlive channel is closed"))
+				eerr := NewEtcdErr("", "keep-alive", errors.New("KeepAlive channel is closed"))
 				e.ErrCh <- eerr
 				return
 			}


### PR DESCRIPTION
By now, Faythe doesn't recognize the keep-alive channel is closed (If etcd server is down or connection is unstable....).