### PR TITLE
Sync silences improvement

### DIFF
--- a/docs/autohealing.md
+++ b/docs/autohealing.md
@@ -107,10 +107,13 @@ If your metric backend is `Prometheus`, Faythe is able to sync from Prometheus A
 
 Faythe doesn't get all the silences from Prometheus Alertmanager. Here are the restricted conditions user has to follow when creating Prometheus Alertmanager's silence:
 
-- Silence's comment has to start with `[faythe]` prefix. For example:
+- Silence's comment has to start with `[faythe]` prefix and contains all Faythe healer's tags. For example:
 
 ```
-Comment: '[faythe] Silence for maintainance'
+# Faythe Healer's tags
+Tags: ["autohealing", "openstack-production-cluster"]
+# Alertmanager silence's comment
+Comment: '[faythe][autohealing][openstack-production-cluster] Silence for maintainance'
 ```
 
 - Silence's matcher has to be on `instance` label.

--- a/docs/autohealing.md
+++ b/docs/autohealing.md
@@ -94,10 +94,14 @@ If your metric backend is `Prometheus`, Faythe is able to sync from Prometheus A
 - Faythe retrieves the Prometheus backend's configuration then get Prometheus Alertmanager's urls and setup clients.
 - Faythe queries the active silences which satisfy [conditions](#222-conditions) from Prometheus Alertmanagers every **60 seconds** (Yes, this is fixed value, at least by now), converts them to Faythe silence format.
 - The Healer's silences dict will be updated with the new silences.
-- Note that, to reduce complexity, this is the **APPEND ONLY** process.
-  - Faythe will create a _complete new silence_ if there is a insert/update from Prometheus Alertmanager.
-  - If user expires silence in Prometheus Alermanager, Faythe won't notice that, silence will still be there.
-  - There are many cases when Alertmanager's silences changes. Faythe and Alertmanager silence creation logic are different, so trying to make them sync 100% with each other is a waste of time.
+- Note that, to reduce complexity, this is **one-way sync process from Alertmanager to Faythe**.
+- The logic is quite simple:
+
+| Alertmanager                  | Faythe                                                                                             |
+| ----------------------------- | -------------------------------------------------------------------------------------------------- |
+| Create/recreate a new silence | Create a new silence                                                                               |
+| Edit a silence                | Find the exist silence, check if pattern/expiration time was updated, force recreate a new silence |
+| Expire a silence              | Delete the exist silence                                                                           |
 
 #### 2.2.2. Conditions
 

--- a/pkg/autohealer/healer.go
+++ b/pkg/autohealer/healer.go
@@ -489,9 +489,10 @@ func (h *Healer) syncSilencesFromBackend(ctx context.Context, e *common.Etcd) {
 				if existSilItf, ok := h.silences.Get(s.ID); ok {
 					existSil := existSilItf.(*model.Silence)
 					if existSil.ExpiredAt != s.ExpiredAt || existSil.Pattern != s.Pattern {
+						level.Debug(h.logger).Log("msg", "Delete the outdated synced silence")
 						_, err := e.DoDelete(path, etcdv3.WithPrefix())
 						if err != nil {
-							level.Error(h.logger).Log("msg", "Error when deleting the outdated of silence",
+							level.Error(h.logger).Log("msg", "Error when deleting the outdated synced silence",
 								"err", err)
 							continue
 						}
@@ -517,7 +518,7 @@ func (h *Healer) syncSilencesFromBackend(ctx context.Context, e *common.Etcd) {
 				level.Info(h.logger).Log("msg", "Create a silence successfully", "id", s.ID)
 			}
 
-			for id, silence  := range h.silences.Items() {
+			for id, silence := range h.silences.Items() {
 				sil := silence.(*model.Silence)
 				// If there is a synced silence exist on Faythe but is no longer
 				// available on Alertmanager, delete it.
@@ -525,10 +526,11 @@ func (h *Healer) syncSilencesFromBackend(ctx context.Context, e *common.Etcd) {
 					continue
 				}
 				if _, ok := silencesMap[id]; !ok {
+					level.Debug(h.logger).Log("msg", "Delete the outdated synced silence")
 					path := common.Path(model.DefaultSilencePrefix, h.CloudID, id)
 					_, err := e.DoDelete(path, etcdv3.WithPrefix())
 					if err != nil {
-						level.Error(h.logger).Log("msg", "Error when deleting the outdated of silence",
+						level.Error(h.logger).Log("msg", "Error when deleting the outdated synced silence",
 							"err", err)
 						continue
 					}

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -35,6 +35,7 @@ const (
 	DefaultSilencePrefix             = "/silences"
 	DefaultSilenceValidationInterval = "30s"
 	DefaultSyncSilencesInterval      = "60s"
+	DefaultSyncedSilenceName         = "Auto sync silence from Alertmanger"
 
 	// DefaultUserPrefix is default etcd prefix for Users
 	DefaultUsersPrefix = "/users"

--- a/pkg/model/const.go
+++ b/pkg/model/const.go
@@ -36,6 +36,7 @@ const (
 	DefaultSilenceValidationInterval = "30s"
 	DefaultSyncSilencesInterval      = "60s"
 	DefaultSyncedSilenceName         = "Auto sync silence from Alertmanger"
+	DefaultSyncSilencePrefix         = "[faythe]"
 
 	// DefaultUserPrefix is default etcd prefix for Users
 	DefaultUsersPrefix = "/users"

--- a/pkg/model/silence.go
+++ b/pkg/model/silence.go
@@ -54,6 +54,9 @@ func (s *Silence) Validate() error {
 	s.RegexPattern = regex
 
 	if s.TTL == "" && !s.CreatedAt.IsZero() && !s.ExpiredAt.IsZero() {
+		if s.CreatedAt.Before(time.Now()) {
+			s.CreatedAt = time.Now()
+		}
 		durationHours := int(math.RoundToEven(s.ExpiredAt.Sub(s.CreatedAt).Hours()))
 		s.TTL = strconv.Itoa(durationHours) + "h"
 	} else if s.TTL != "" {

--- a/pkg/model/silence.go
+++ b/pkg/model/silence.go
@@ -69,7 +69,9 @@ func (s *Silence) Validate() error {
 		return fmt.Errorf("silence ttl, created_at and expired_at cannot be both empty")
 	}
 
-	s.ID = common.Hash(fmt.Sprintf("%s-%s", s.Pattern, s.ExpiredAt.String()), crypto.MD5)
+	if s.ID == "" {
+		s.ID = common.Hash(fmt.Sprintf("%s-%s", s.Pattern, s.ExpiredAt.String()), crypto.MD5)
+	}
 
 	return nil
 }


### PR DESCRIPTION
- Use concurrent map.
- Use AM silence's ID as Faythe silence's ID as well.
- If there is an outdated silence, force recreate it.
- If there is a synced silence exist on Faythe but
is no longer available on Alertmanager, delete it.
- Change Alertmanager's silence conditions.