### PR TITLE
Remove goroutine in listscalers to avoid concurrent map writes

### DIFF
--- a/api/scaler.go
+++ b/api/scaler.go
@@ -144,14 +144,14 @@ func (a *API) listScalers(w http.ResponseWriter, req *http.Request) {
 		if fTags := req.FormValue("tags"); fTags != "" {
 			tags := strings.Split(fTags, ",")
 			if !common.Find(s.Tags, tags, "and") {
-				return
+				continue
 			}
 		}
 		// Clouds that match any tags in this list will be returned
 		if fTagsAny := req.FormValue("tags-any"); fTagsAny != "" {
 			tags := strings.Split(fTagsAny, ",")
 			if !common.Find(s.Tags, tags, "or") {
-				return
+				continue
 			}
 		}
 		scalers.Set(string(ev.Key), s)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14995336/180356807-0b5b1832-48b8-4132-ba9f-1bbfc7cb0e39.png)


No time to investigate. 

Dunno if https://github.com/vCloud-DFTBA/faythe/blob/master/api/scaler.go#L149-L154 , based on the Trace then the problem is in the http lib :'( or we're using that wrong

```go
			if fTags := req.FormValue("tags"); fTags != "" {
				tags := strings.Split(fTags, ",")
				if !common.Find(s.Tags, tags, "and") {
					return
				}
```

Can cause error or  https://github.com/vCloud-DFTBA/faythe/blob/master/api/scaler.go#L162

```go
			scalers.Set(evk, s)
```

this one already uses `cmap`, so it's not likely the issue here.
